### PR TITLE
ENH: Allow the build, test, package workflow to be triggered

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,26 +13,26 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.2rc03"
+            itk-git-tag: "v5.2.0"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.2rc03"
+            itk-git-tag: "v5.2.0"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.2rc03"
+            itk-git-tag: "v5.2.0"
             cmake-build-type: "MinSizeRel"
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install build dependencies
       run: |
@@ -130,13 +130,13 @@ jobs:
       shell: cmd
 
   build-linux-python-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 2
       matrix:
         python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.2rc03"
+          - itk-python-git-tag: "v5.2.0.post2"
 
     steps:
     - uses: actions/checkout@v2
@@ -172,7 +172,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.2rc03"
+          - itk-python-git-tag: "v5.2.0.post2"
 
     steps:
     - uses: actions/checkout@v2
@@ -208,7 +208,7 @@ jobs:
       matrix:
         python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.2rc03"
+          - itk-python-git-tag: "v5.2.0.post2"
 
     steps:
     - name: Get specific version of CMake, Ninja

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -4,7 +4,7 @@ on: [push,pull_request]
 
 jobs:
   build-test-cxx:
-    runs-on: ${{ "{{" }} matrix.os {{ "}}" }}
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 3
       matrix:
@@ -47,7 +47,7 @@ jobs:
         cd ..
         git clone https://github.com/InsightSoftwareConsortium/ITK.git
         cd ITK
-        git checkout ${{ "{{" }} matrix.itk-git-tag {{ "}}" }}
+        git checkout ${{ matrix.itk-git-tag }}
 
     - name: Build ITK
       if: matrix.os != 'windows-2019'
@@ -55,7 +55,7 @@ jobs:
         cd ..
         mkdir ITK-build
         cd ITK-build
-        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ "{{" }} matrix.c-compiler {{ "}}" }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ "{{" }} matrix.cxx-compiler {{ "}}" }}" -DCMAKE_BUILD_TYPE:STRING=${{ "{{" }} matrix.cmake-build-type {{ "}}" }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
         ninja
 
     - name: Build ITK
@@ -65,7 +65,7 @@ jobs:
         mkdir ITK-build
         cd ITK-build
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ "{{" }} matrix.c-compiler {{ "}}" }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ "{{" }} matrix.cxx-compiler {{ "}}" }}" -DCMAKE_BUILD_TYPE:STRING=${{ "{{" }} matrix.cmake-build-type {{ "}}" }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
         ninja
       shell: cmd
 
@@ -76,7 +76,7 @@ jobs:
     - name: Configure CTest script
       shell: bash
       run: |
-        operating_system="${{ "{{" }} matrix.os {{ "}}" }}"
+        operating_system="${{ matrix.os }}"
         cat > dashboard.cmake << EOF
         set(CTEST_SITE "GitHubActions")
         file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/.." CTEST_DASHBOARD_ROOT)
@@ -101,8 +101,8 @@ jobs:
           "ld: warning: text-based stub file"
           )
         set(dashboard_no_clean 1)
-        set(ENV{CC} ${{ "{{" }} matrix.c-compiler {{ "}}" }})
-        set(ENV{CXX} ${{ "{{" }} matrix.cxx-compiler {{ "}}" }})
+        set(ENV{CC} ${{ matrix.c-compiler }})
+        set(ENV{CXX} ${{ matrix.cxx-compiler }})
         if(WIN32)
           set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
         endif()
@@ -157,13 +157,13 @@ jobs:
 
     - name: 'Build 🐍 Python 📦 package'
       run: |
-        export ITK_PACKAGE_VERSION=${{ "{{" }} matrix.itk-python-git-tag {{ "}}" }}
-        ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ "{{" }} matrix.python-version {{ "}}" }}
+        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
+        ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }}
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v1
       with:
-        name: LinuxWheel${{ "{{" }} matrix.python-version {{ "}}" }}
+        name: LinuxWheel${{ matrix.python-version }}
         path: dist
 
   build-macos-python-packages:
@@ -191,7 +191,7 @@ jobs:
 
     - name: 'Build 🐍 Python 📦 package'
       run: |
-        export ITK_PACKAGE_VERSION=${{ "{{" }} matrix.itk-python-git-tag {{ "}}" }}
+        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
         export MACOSX_DEPLOYMENT_TARGET=10.9
         ./macpython-download-cache-and-build-module-wheels.sh
 
@@ -221,7 +221,7 @@ jobs:
     - name: 'Install Python'
       run: |
         $pythonArch = "64"
-        $pythonVersion = "3.${{ "{{" }} matrix.python-version-minor {{ "}}" }}"
+        $pythonVersion = "3.${{ matrix.python-version-minor }}"
         iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1'))
 
     - name: 'Fetch build dependencies'
@@ -229,7 +229,7 @@ jobs:
       run: |
         mv im ../../
         cd ../../im
-        curl -L "https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${{ "{{" }} matrix.itk-python-git-tag {{ "}}" }}/ITKPythonBuilds-windows.zip" -o "ITKPythonBuilds-windows.zip"
+        curl -L "https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${{ matrix.itk-python-git-tag }}/ITKPythonBuilds-windows.zip" -o "ITKPythonBuilds-windows.zip"
         7z x ITKPythonBuilds-windows.zip -o/c/P -aoa -r
         curl -L "https://data.kitware.com/api/v1/file/5c0ad59d8d777f2179dd3e9c/download" -o "doxygen-1.8.11.windows.bin.zip"
         7z x doxygen-1.8.11.windows.bin.zip -o/c/P/doxygen -aoa -r
@@ -244,12 +244,12 @@ jobs:
         set PATH="C:\P\grep;%PATH%"
         set CC=cl.exe
         set CXX=cl.exe
-        C:\Python3${{ "{{" }} matrix.python-version-minor {{ "}}" }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ "{{" }} matrix.python-version-minor {{ "}}" }}-x64" --no-cleanup
+        C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64" --no-cleanup
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v1
       with:
-        name: WindowsWheel3.${{ "{{" }} matrix.python-version-minor {{ "}}" }}
+        name: WindowsWheel3.${{ matrix.python-version-minor }}
         path: ../../im/dist
 
   publish-python-packages-to-pypi:
@@ -278,4 +278,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
-        password: ${{ "{{" }} secrets.pypi_password {{ "}}" }}
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Allow the build, test, package workflow to be triggered: remove the unnecessary braces around the workflow file variables.

Update the workflow file to match the latest ITK version as well as the remote modules' latest recommended versions.