### PR TITLE
ENH: Replacing QEMesh Curvature with TriangleMesh Curvature

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.2.0"
+            itk-git-tag: "2cc4bdb5e34a3053a3641a1e92cbd3f7946e5c87"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.2.0"
+            itk-git-tag: "2cc4bdb5e34a3053a3641a1e92cbd3f7946e5c87"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.2.0"
+            itk-git-tag: "2cc4bdb5e34a3053a3641a1e92cbd3f7946e5c87"
             cmake-build-type: "MinSizeRel"
 
     steps:

--- a/examples/test_tsd_affine.py
+++ b/examples/test_tsd_affine.py
@@ -1,0 +1,150 @@
+# [THINSHELLDEMONS] Read Mesh and Create TSD object
+
+# Build the Module with Python Wrapping and import the itk package which is available under Wrapping/Generators/Python
+#import sys
+#sys.path.append('/home/pranjal.sahu/ITKPR7/ITK/ITK-build/Wrapping/Generators/Python')
+
+import itkConfig
+itkConfig.LazyLoading = False
+
+import numpy as np
+import itk
+from itk import itkThinShellDemonsMetricv4Python as tsd
+from itk import itkConjugateGradientLineSearchOptimizerv4Python as itkc
+import math
+
+
+fixedMesh = itk.meshread('../test/Baseline/fixedMesh.vtk', itk.D)
+movingMesh = itk.meshread('../test/Baseline/movingMesh.vtk', itk.D)
+
+fixedMesh.BuildCellLinks()
+movingMesh.BuildCellLinks()
+
+PixelType = itk.D
+Dimension = 3
+
+MeshType = itk.Mesh[itk.D, Dimension]
+FixedImageType = itk.Image[PixelType, Dimension]
+MovingImageType = itk.Image[PixelType, Dimension]
+
+
+# For getting the Bounding Box
+ElementIdentifierType = itk.UL
+CoordType = itk.F
+Dimension = 3
+
+VecContType = itk.VectorContainer[
+    ElementIdentifierType, itk.Point[CoordType, Dimension]
+]
+bounding_box = itk.BoundingBox[ElementIdentifierType, Dimension, CoordType, VecContType].New()
+bounding_box.SetPoints(movingMesh.GetPoints())
+bounding_box.ComputeBoundingBox()
+
+minBounds = np.array(bounding_box.GetMinimum())
+maxBounds = np.array(bounding_box.GetMaximum())
+
+imageDiagonal = 5
+spacing = np.sqrt(bounding_box.GetDiagonalLength2()) / imageDiagonal
+diff = maxBounds - minBounds
+
+fixedImageSize = [0]*3
+fixedImageSize[0] = math.ceil( 1.2 * diff[0] / spacing )
+fixedImageSize[1] = math.ceil( 1.2 * diff[1] / spacing )
+fixedImageSize[2] = math.ceil( 1.2 * diff[2] / spacing )
+
+fixedImageOrigin = [0]*3
+fixedImageOrigin[0] = minBounds[0] - 0.1 * diff[0]
+fixedImageOrigin[1] = minBounds[1] - 0.1 * diff[1]
+fixedImageOrigin[2] = minBounds[2] - 0.1 * diff[2]
+
+fixedImageSpacing = np.ones(3)*spacing
+fixedImageDirection = np.identity(3)
+
+
+fixedImage = FixedImageType.New()
+fixedImage.SetRegions(fixedImageSize)
+fixedImage.SetOrigin( fixedImageOrigin )
+fixedImage.SetDirection( fixedImageDirection )
+fixedImage.SetSpacing( fixedImageSpacing )
+fixedImage.Allocate()
+
+
+# Affine Transform Object
+TransformType = itk.AffineTransform.D3
+transform = TransformType.New()
+transform.SetIdentity()
+transform.SetCenter(minBounds + (maxBounds - minBounds)/2)
+
+print('Transform Created')
+print(transform)
+
+
+MetricType = tsd.itkThinShellDemonsMetricv4MD3
+metric = MetricType.New()
+metric.SetStretchWeight(1)
+metric.SetBendWeight(5)
+metric.SetGeometricFeatureWeight(10)
+metric.UseConfidenceWeightingOn()
+metric.UseMaximalDistanceConfidenceSigmaOn()
+metric.UpdateFeatureMatchingAtEachIterationOff()
+metric.SetMovingTransform(transform)
+# Reversed due to using points instead of an image
+# to keep semantics the same as in itkThinShellDemonsTest.cxx
+# For the ThinShellDemonsMetricv4 the fixed mesh is regularized
+metric.SetFixedPointSet(movingMesh)
+metric.SetMovingPointSet(fixedMesh)
+metric.SetVirtualDomainFromImage(fixedImage)
+metric.Initialize()
+
+print('TSD Metric Created')
+
+shiftScaleEstimator = itk.RegistrationParameterScalesFromPhysicalShift[MetricType].New()
+shiftScaleEstimator.SetMetric(metric)
+shiftScaleEstimator.SetVirtualDomainPointSet(metric.GetVirtualTransformedPointSet())
+
+
+optimizer = itkc.itkConjugateGradientLineSearchOptimizerv4TemplateD.New()
+optimizer.SetNumberOfIterations( 50 )
+optimizer.SetScalesEstimator( shiftScaleEstimator )
+optimizer.SetMaximumStepSizeInPhysicalUnits( 0.5 )
+optimizer.SetMinimumConvergenceValue( 0.0 )
+optimizer.SetConvergenceWindowSize( 10 )
+
+def iteration_update():
+    metric_value = optimizer.GetValue()
+    current_parameters = optimizer.GetCurrentPosition()
+    print(f"Metric: {metric_value:.8g}")
+
+iteration_command = itk.PyCommand.New()
+iteration_command.SetCommandCallable(iteration_update)
+optimizer.AddObserver(itk.IterationEvent(), iteration_command)
+
+print('Optimizer created')
+
+
+AffineRegistrationType = itk.ImageRegistrationMethodv4.REGv4D3D3TD3D3MD3.New()
+registration = AffineRegistrationType.New()
+registration.SetNumberOfLevels(1)
+registration.SetObjectName("registration")
+registration.SetFixedPointSet(movingMesh)
+registration.SetMovingPointSet(fixedMesh)
+registration.SetInitialTransform(transform)
+registration.SetMetric(metric)
+registration.SetOptimizer(optimizer)
+
+print('Registration Object created')
+print('Initial Value of Metric ', metric.GetValue())
+
+try:
+    registration.Update()
+except e:
+    print('Error is ', e)
+
+print('Final Value of Metric ', metric.GetValue())
+
+finalTransform = registration.GetModifiableTransform()
+numberOfPoints = movingMesh.GetNumberOfPoints()
+for n in range(0, numberOfPoints):
+    movingMesh.SetPoint(n, finalTransform.TransformPoint(movingMesh.GetPoint(n)))
+
+itk.meshwrite(movingMesh, "affineMovingMesh.vtk")

--- a/examples/test_tsd_syn.py
+++ b/examples/test_tsd_syn.py
@@ -1,0 +1,175 @@
+# [THINSHELLDEMONS] Read Mesh and Create TSD object
+
+# Build the Module with Python Wrapping and import the itk package which is available under Wrapping/Generators/Python
+#import sys
+#sys.path.append('/home/pranjal.sahu/ITKPR7/ITK/ITK-build/Wrapping/Generators/Python')
+
+import itkConfig
+itkConfig.LazyLoading = False
+
+import numpy as np
+import itk
+from itk import itkThinShellDemonsMetricv4Python as tsd
+from itk import itkConjugateGradientLineSearchOptimizerv4Python as itkc
+import math
+
+
+fixedMesh = itk.meshread('../test/Baseline/fixedMesh.vtk', itk.D)
+movingMesh = itk.meshread('../test/Baseline/movingMesh.vtk', itk.D)
+
+fixedMesh.BuildCellLinks()
+movingMesh.BuildCellLinks()
+
+PixelType = itk.D
+Dimension = 3
+
+MeshType = itk.Mesh[itk.D, Dimension]
+FixedImageType = itk.Image[PixelType, Dimension]
+MovingImageType = itk.Image[PixelType, Dimension]
+
+
+# For getting the Bounding Box
+ElementIdentifierType = itk.UL
+CoordType = itk.F
+Dimension = 3
+
+VecContType = itk.VectorContainer[
+    ElementIdentifierType, itk.Point[CoordType, Dimension]
+]
+bounding_box = itk.BoundingBox[ElementIdentifierType, Dimension, CoordType, VecContType].New()
+bounding_box.SetPoints(movingMesh.GetPoints())
+bounding_box.ComputeBoundingBox()
+
+minBounds = np.array(bounding_box.GetMinimum())
+maxBounds = np.array(bounding_box.GetMaximum())
+
+imageDiagonal = 100
+spacing = np.sqrt(bounding_box.GetDiagonalLength2()) / imageDiagonal
+diff = maxBounds - minBounds
+
+fixedImageSize = [0]*3
+fixedImageSize[0] = math.ceil( 1.2 * diff[0] / spacing )
+fixedImageSize[1] = math.ceil( 1.2 * diff[1] / spacing )
+fixedImageSize[2] = math.ceil( 1.2 * diff[2] / spacing )
+
+fixedImageOrigin = [0]*3
+fixedImageOrigin[0] = minBounds[0] - 0.1 * diff[0]
+fixedImageOrigin[1] = minBounds[1] - 0.1 * diff[1]
+fixedImageOrigin[2] = minBounds[2] - 0.1 * diff[2]
+
+fixedImageSpacing = np.ones(3)*spacing
+fixedImageDirection = np.identity(3)
+
+
+fixedImage = FixedImageType.New()
+fixedImage.SetRegions(fixedImageSize)
+fixedImage.SetOrigin( fixedImageOrigin )
+fixedImage.SetDirection( fixedImageDirection )
+fixedImage.SetSpacing( fixedImageSpacing )
+fixedImage.Allocate()
+
+VectorType = itk.Vector[itk.D, Dimension]
+zeroVector = VectorType()
+zeroVector.Fill(0)
+
+DisplacementFieldType = itk.Image[VectorType, Dimension]
+
+displacementField = DisplacementFieldType.New()
+displacementField.CopyInformation(fixedImage)
+displacementField.SetRegions(fixedImage.GetBufferedRegion())
+displacementField.Allocate()
+displacementField.FillBuffer(zeroVector)
+
+inverseDisplacementField = DisplacementFieldType.New()
+inverseDisplacementField.CopyInformation(fixedImage)
+inverseDisplacementField.SetRegions(fixedImage.GetBufferedRegion())
+inverseDisplacementField.Allocate()
+inverseDisplacementField.FillBuffer(zeroVector)
+
+TransformType = itk.DisplacementFieldTransform[itk.D, Dimension]
+
+DisplacementFieldRegistrationType = itk.SyNImageRegistrationMethod[FixedImageType, MovingImageType,
+            TransformType, FixedImageType, MeshType]
+registration  = DisplacementFieldRegistrationType.New()
+
+OutputTransformType = TransformType
+outputTransform = OutputTransformType.New()
+outputTransform.SetDisplacementField(displacementField)
+outputTransform.SetInverseDisplacementField(inverseDisplacementField)
+registration.SetInitialTransform(outputTransform)
+registration.InPlaceOn()
+
+
+# Affine Transform Object
+AffineTransformType = itk.AffineTransform.D3
+transform = AffineTransformType.New()
+transform.SetIdentity()
+transform.SetCenter(minBounds + (maxBounds - minBounds)/2)
+
+print('Transform Created')
+print(transform)
+
+
+MetricType = tsd.itkThinShellDemonsMetricv4MD3
+metric = MetricType.New()
+metric.SetStretchWeight(1)
+metric.SetBendWeight(5)
+metric.SetGeometricFeatureWeight(10)
+metric.UseConfidenceWeightingOn()
+metric.UseMaximalDistanceConfidenceSigmaOn()
+metric.UpdateFeatureMatchingAtEachIterationOff()
+metric.SetMovingTransform(transform)
+# Reversed due to using points instead of an image
+# to keep semantics the same as in itkThinShellDemonsTest.cxx
+# For the ThinShellDemonsMetricv4 the fixed mesh is regularized
+metric.SetFixedPointSet(movingMesh)
+metric.SetMovingPointSet(fixedMesh)
+metric.SetVirtualDomainFromImage(fixedImage)
+metric.Initialize()
+
+print('TSD Metric Created')
+
+varianceForUpdateField = spacing*spacing*25
+varianceForTotalField = 0.0
+registration.SetGaussianSmoothingVarianceForTheUpdateField(varianceForUpdateField)
+registration.SetGaussianSmoothingVarianceForTheTotalField(varianceForTotalField)
+registration.SetFixedPointSet(movingMesh)
+registration.SetMovingPointSet(fixedMesh)
+registration.SetMovingInitialTransform(transform)
+registration.SetMetric(metric)
+
+
+numberOfLevels = 3
+registration.SetNumberOfLevels(numberOfLevels)
+numberOfIterationsPerLevel = itk.Array[itk.UI]()
+numberOfIterationsPerLevel.SetSize(numberOfLevels)
+numberOfIterationsPerLevel[0] = 5
+numberOfIterationsPerLevel[1] = 10
+numberOfIterationsPerLevel[2] = 50
+registration.SetNumberOfIterationsPerLevel(numberOfIterationsPerLevel)
+
+shrinkFactorsPerLevel  = itk.Array[itk.UI]()
+shrinkFactorsPerLevel.SetSize(numberOfLevels)
+shrinkFactorsPerLevel.Fill(1)
+
+smoothingSigmasPerLevel = itk.Array[itk.UI]()
+smoothingSigmasPerLevel.SetSize(numberOfLevels)
+smoothingSigmasPerLevel.Fill(0)
+
+registration.SetShrinkFactorsPerLevel(shrinkFactorsPerLevel)
+registration.SetSmoothingSigmasPerLevel(smoothingSigmasPerLevel)
+
+print('Initial Value of Metric ', metric.GetValue())
+try:
+    registration.Update()
+except:
+    print('Error Occured')
+
+print('Final Value of Metric ', metric.GetValue())
+
+finalTransform = registration.GetModifiableTransform()
+numberOfPoints = movingMesh.GetNumberOfPoints()
+for n in range(0, numberOfPoints):
+    movingMesh.SetPoint(n, finalTransform.TransformPoint(movingMesh.GetPoint(n)))
+
+itk.meshwrite(movingMesh, "synMovingMesh.vtk")

--- a/include/itkThinShellDemonsMetricv4.h
+++ b/include/itkThinShellDemonsMetricv4.h
@@ -20,12 +20,8 @@
 
 #include "itkPointSetToPointSetMetricWithIndexv4.h"
 
-#include <itkMesh.h>
-#include <itkQuadEdge.h>
-#include <itkQuadEdgeMesh.h>
-#include <itkQuadEdgeMeshExtendedTraits.h>
-#include <itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h>
-
+#include "itkMesh.h"
+#include "itkTriangleMeshCurvatureCalculator.h"
 #include "itkMeshFileWriter.h"
 #include "itkMeshFileReader.h"
 
@@ -97,26 +93,17 @@ public:
 
   using VectorType = typename itk::Vector<double, PointType::Dimension>;
 
-  /* For the QE Mesh and to obtain the curvature using it */
   using CoordType = float;
-  using QETraits = typename itk::QuadEdgeMeshExtendedTraits<CoordType, PointType::Dimension, 2, CoordType, CoordType, CoordType, bool, bool>;
-  using QEMeshType = typename itk::QuadEdgeMesh<CoordType, PointType::Dimension, QETraits>;
-  using QEMeshTypePointer = typename QEMeshType::Pointer;
-  using QEPointsContainerPointer = typename QEMeshType::PointsContainerPointer;
-
   using MeshType = TFixedMesh;
   using MeshTypePointer = typename MeshType::Pointer;
   using MeshCellType = typename MeshType::CellType;
+  using PointDataContainer = typename MeshType::PointDataContainer;
+  using PointDataContainerPointer = typename PointDataContainer::Pointer;
   using MeshCellPointIdConstIterator = typename MeshCellType::PointIdConstIterator;
   using MeshCellAutoPointer = typename MeshCellType::CellAutoPointer;
   using MeshTriangleCellType = itk::TriangleCell<MeshCellType>;
 
-  using QEMeshPointType = typename QEMeshType::PointType;
-  using QECellType = typename QEMeshType::CellType;
-  using QECellAutoPointer = typename QECellType::SelfAutoPointer;
-  using QETriangleCellType = itk::TriangleCell<QECellType>;
-  
-  using CurvatureFilterType = typename itk::DiscreteGaussianCurvatureQuadEdgeMeshFilter<QEMeshType, QEMeshType>;
+  using CurvatureFilterType = typename itk::TriangleMeshCurvatureCalculator<MeshType>;
   using CurvatureFilterTypePointer = typename CurvatureFilterType::Pointer;
 
   using PointSetPointer = typename Superclass::FixedPointSetType::ConstPointer;
@@ -245,11 +232,9 @@ private:
 
   mutable MeshTypePointer fixedITKMesh;
   mutable MeshTypePointer movingITKMesh;
-  mutable QEMeshTypePointer fixedQEMesh;
-  mutable QEMeshTypePointer movingQEMesh;
-  mutable QEMeshTypePointer fixedCurvature;
+  mutable MeshTypePointer fixedCurvature;
 
-  CurvatureFilterTypePointer gaussian_curvature_filter;
+  CurvatureFilterTypePointer curvature_filter;
 
   double m_StretchWeight;
   double m_BendWeight;

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -15,11 +15,11 @@ itk_module(ThinShellDemons
   ENABLE_SHARED
   COMPILE_DEPENDS
     ITKCommon
-	  ITKMesh
+    ITKMesh
     ITKIOMeshBase
-	  ITKRegistrationCommon
-	  ITKQuadEdgeMesh
-	  ITKQuadEdgeMeshFiltering
+    ITKRegistrationCommon
+    ITKQuadEdgeMesh
+    ITKQuadEdgeMeshFiltering
     ITKMetricsv4
     ITKRegistrationMethodsv4
     ITKOptimizersv4

--- a/test/itkThinShellDemonsTestv4_Affine.cxx
+++ b/test/itkThinShellDemonsTestv4_Affine.cxx
@@ -71,7 +71,7 @@ int itkThinShellDemonsTestv4_Affine( int args, char *argv [])
   using ReaderType = itk::MeshFileReader<MeshType>;
   using WriterType = itk::MeshFileWriter<MeshType>;
 
-  unsigned int numberOfIterations = 100;
+  unsigned int numberOfIterations = 50;
 
   /*
   Initialize fixed mesh polydata reader
@@ -192,7 +192,7 @@ int itkThinShellDemonsTestv4_Affine( int args, char *argv [])
 */
   typedef itk::ConjugateGradientLineSearchOptimizerv4 OptimizerType;
   OptimizerType::Pointer optimizer = OptimizerType::New();
-  optimizer->SetNumberOfIterations( 50 );
+  optimizer->SetNumberOfIterations( numberOfIterations );
   optimizer->SetScalesEstimator( shiftScaleEstimator );
   optimizer->SetMaximumStepSizeInPhysicalUnits( 0.5 );
   optimizer->SetMinimumConvergenceValue( 0.0 );

--- a/wrapping/itkThinShellDemonsMetricv4.wrap
+++ b/wrapping/itkThinShellDemonsMetricv4.wrap
@@ -2,12 +2,12 @@ itk_wrap_include("itkPointSet.h")
 itk_wrap_include("itkMesh.h")
 itk_wrap_include("itkDefaultStaticMeshTraits.h")
 
-UNIQUE(types "${WRAP_ITK_SCALAR};D")
+UNIQUE(types "${WRAP_ITK_REAL};D")
 
 itk_wrap_class("itk::ThinShellDemonsMetricv4" POINTER_WITH_2_SUPERCLASSES)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${types})
-      itk_wrap_template("PS${ITKM_${t}}${d}" "itk::Mesh< ${ITKT_${t}},${d} >")
+      itk_wrap_template("M${ITKM_${t}}${d}" "itk::Mesh< ${ITKT_${t}},${d} >")
     endforeach()
   endforeach()
 itk_end_wrap_class()
@@ -15,7 +15,7 @@ itk_end_wrap_class()
 itk_wrap_class("itk::RegistrationParameterScalesFromPhysicalShift" POINTER_WITH_2_SUPERCLASSES)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${types})
-      itk_wrap_template("EBPSTPSMPS${ITKM_${t}}${d}"
+      itk_wrap_template("TSDMTMMM${ITKM_${t}}${d}"
         "itk::ThinShellDemonsMetricv4< itk::Mesh< ${ITKT_${t}},${d} > >")
     endforeach()
   endforeach()


### PR DESCRIPTION
Quad Edge Mesh based curvature calculation has been replaced with newly added TriangleMesh Curvature.
End-to-End working example in Python for Affine Registration is added.
Correct name mangling for Mesh is used.
The metric values are same as before the introduction of Quad Edge Mesh based curvature.
Python building will require update in the tags.