### PR TITLE
ENH: Handle meshes having points not present in any cell

### DIFF
--- a/include/itkThinShellDemonsMetricv4.hxx
+++ b/include/itkThinShellDemonsMetricv4.hxx
@@ -253,8 +253,11 @@ ThinShellDemonsMetricv4< TFixedMesh, TMovingMesh, TInternalComputationValueType 
     bend += dx * (degree * 4 / (degree+nDegree));
     }
 
-  bendEnergy = bEnergy.GetSquaredNorm() / degree;
-  stretchEnergy /= degree;
+  if (degree > 0)
+  {
+    bendEnergy = bEnergy.GetSquaredNorm() / degree;
+    stretchEnergy /= degree;
+  }
 }
 
 /* Function definition of the original method definition in itkPointSetToPointSetMetric*/


### PR DESCRIPTION
When the point has no neighbours the loss would become nan due to division by 0.
To handle such meshes adding a check to avoid division by 0.