### PR TITLE
STYLE: Prefer using `https` instead of `http` in copyright notice

### DIFF
--- a/include/itkThinShellDemonsMetricv4.h
+++ b/include/itkThinShellDemonsMetricv4.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkThinShellDemonsMetricv4.hxx
+++ b/include/itkThinShellDemonsMetricv4.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkThinShellDemonsTestv4_Affine.cxx
+++ b/test/itkThinShellDemonsTestv4_Affine.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkThinShellDemonsTestv4_Displacement.cxx
+++ b/test/itkThinShellDemonsTestv4_Displacement.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkThinShellDemonsTestv4_SyN.cxx
+++ b/test/itkThinShellDemonsTestv4_SyN.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Prefer using `https` instead of `http` in copyright notice license link.

Changed in https://github.com/InsightSoftwareConsortium/ITK/pull/3428.